### PR TITLE
Adding debug printing to master

### DIFF
--- a/src/aztec/gpu/curves/element.cuh
+++ b/src/aztec/gpu/curves/element.cuh
@@ -24,6 +24,13 @@ class element {
         __device__ __forceinline__ element(const fq_gpu &a, const fq_gpu &b, const fq_gpu &c) noexcept;
         
         __device__ __forceinline__ element(const element& other) noexcept;
+
+        /*
+        Print statement for debugging purposes
+        */
+        friend std::ostream& operator<<(std::ostream& os, element const & tc) {
+            return os << "x = " << tc.x << ", y = " << tc.y << ", z = " << tc.z << endl;
+    }
 };
 
 /* -------------------------- Affine Representation ---------------------------------------------- */

--- a/src/aztec/gpu/fields/field.cuh
+++ b/src/aztec/gpu/fields/field.cuh
@@ -220,6 +220,11 @@ class field_gpu {
         __device__ __forceinline__ static var from_monty(var x, var &res);
 
         __device__ __forceinline__ static var neg(var &x, var &res);
+
+        //For debugging, this print ties directly into the print statement found in element.cuh on line 31
+        friend std::ostream& operator<<(std::ostream &os, field_gpu const &m) { 
+            return os << m.data[0] << m.data[1] << m.data[2] << m.data[3] << endl;
+        }
 };
 typedef field_gpu<BN254_MOD_BASE> fq_gpu;
 typedef field_gpu<BN254_MOD_SCALAR> fr_gpu;

--- a/src/aztec/gpu/msm/common.cu
+++ b/src/aztec/gpu/msm/common.cu
@@ -3,6 +3,7 @@
 #include <vector>
 
 namespace pippenger_common {
+    point_t host_buckets[26624 * sizeof(point_t)];
 
 /**
  * Execute bucket method
@@ -20,6 +21,10 @@ pippenger_t &config, scalar_t *scalars, point_t *points, unsigned bitsize, unsig
     unsigned NUM_BLOCKS = (config.num_buckets + NUM_THREADS - 1) / NUM_THREADS;
     CUDA_WRAPPER(cudaMallocAsync(&buckets, config.num_buckets * 3 * 4 * sizeof(uint64_t), stream));
     initialize_buckets_kernel<<<NUM_BLOCKS * 4, NUM_THREADS, 0, stream>>>(buckets); 
+
+    //test for printing on master
+    transfer_field_elements_to_host(config, host_buckets, buckets, stream);
+    cout << "First Element After Initialization: " << host_buckets[0] << endl;
 
     // Scalars decomposition kernel
     CUDA_WRAPPER(cudaMallocAsync(&(params->bucket_indices), sizeof(unsigned) * npoints * (windows + 1), stream));
@@ -179,6 +184,33 @@ template <class point_t, class scalar_t>
 void pippenger_t<point_t, scalar_t>::transfer_scalars_to_device(
 pippenger_t &config, scalar_t *device_scalar_ptrs, fr *scalars, cudaStream_t stream) {
     CUDA_WRAPPER(cudaMemcpyAsync(device_scalar_ptrs, scalars, NUM_POINTS * LIMBS * sizeof(uint64_t), cudaMemcpyHostToDevice, stream));
+}
+
+/**
+ * Transfer field elements to host device for debugging purposes
+ */
+template <class point_t, class scalar_t>
+void pippenger_t<point_t, scalar_t>::transfer_field_elements_to_host(
+pippenger_t &config, point_t* host_buckets, point_t* buckets, cudaStream_t stream) {
+    CUDA_WRAPPER(cudaMemcpyAsync(host_buckets, buckets, num_buckets * sizeof(point_t), cudaMemcpyDeviceToHost, stream)); // multiply by 4 to account for the 4 elements being printed in field.cuh
+}
+
+/**
+ * Transfer base points to CPU device
+ */
+template <class point_t, class scalar_t>
+void pippenger_t<point_t, scalar_t>::transfer_bases_to_host(
+pippenger_t &config, point_t *device_bases_ptrs, const point_t *point_buckets, cudaStream_t stream) {    
+    CUDA_WRAPPER(cudaMemcpyAsync(device_bases_ptrs, point_buckets, NUM_POINTS * LIMBS * sizeof(uint64_t), cudaMemcpyDeviceToHost, stream));
+}
+
+/**
+ * Transfer bucket offsets to CPU device
+ */
+template <class point_t, class scalar_t>
+void pippenger_t<point_t, scalar_t>::transfer_offsets_to_host(
+pippenger_t &config, unsigned *host_offsets, unsigned *device_offsets, cudaStream_t stream) {    
+    CUDA_WRAPPER(cudaMemcpyAsync(host_offsets, device_offsets, num_buckets * sizeof(unsigned), cudaMemcpyDeviceToHost, stream));
 }
 
 /**

--- a/src/aztec/gpu/msm/common.cu
+++ b/src/aztec/gpu/msm/common.cu
@@ -23,8 +23,10 @@ pippenger_t &config, scalar_t *scalars, point_t *points, unsigned bitsize, unsig
     initialize_buckets_kernel<<<NUM_BLOCKS * 4, NUM_THREADS, 0, stream>>>(buckets); 
 
     //test for printing on master
+    
     transfer_field_elements_to_host(config, host_buckets, buckets, stream);
     cout << "First Element After Initialization: " << host_buckets[0] << endl;
+    
 
     // Scalars decomposition kernel
     CUDA_WRAPPER(cudaMallocAsync(&(params->bucket_indices), sizeof(unsigned) * npoints * (windows + 1), stream));

--- a/src/aztec/gpu/msm/common.cuh
+++ b/src/aztec/gpu/msm/common.cuh
@@ -75,6 +75,12 @@ class pippenger_t {
         void transfer_bases_to_device(pippenger_t &config, point_t *device_bases_ptrs, const point_t *points, cudaStream_t stream);
         
         void transfer_scalars_to_device(pippenger_t &config, scalar_t *device_scalar_ptrs, fr *scalars, cudaStream_t stream);
+
+        void transfer_bases_to_host(pippenger_t &config, point_t *device_bases_ptrs, const point_t *point_buckets, cudaStream_t stream);
+
+        void transfer_field_elements_to_host(pippenger_t &config, point_t* host_buckets, point_t* buckets, cudaStream_t stream);
+                
+        void transfer_offsets_to_host(pippenger_t &config, unsigned *host_offsets, unsigned *device_offsets, cudaStream_t stream);
                 
         void print_result(g1_gpu::element *result_1, g1_gpu::element **result_2);
         

--- a/src/aztec/gpu/msm/kernel.cu
+++ b/src/aztec/gpu/msm/kernel.cu
@@ -190,6 +190,8 @@ __global__ void initialize_buckets_kernel(g1_gpu::element *bucket) {
     fq_gpu::load(fq_gpu::zero().data[tid % 4], bucket[subgroup + (subgroup_size * blockIdx.x)].x.data[tid % 4]);
     fq_gpu::load(fq_gpu::zero().data[tid % 4], bucket[subgroup + (subgroup_size * blockIdx.x)].y.data[tid % 4]);
     fq_gpu::load(fq_gpu::zero().data[tid % 4], bucket[subgroup + (subgroup_size * blockIdx.x)].z.data[tid % 4]);
+
+    
 }
 
 /**
@@ -217,7 +219,9 @@ __device__ __forceinline__ uint64_t decompose_scalar_digit(fr_gpu scalar, unsign
  * Decompose b-bit scalar into c-bit scalar, where c <= b
  */
 __global__ void split_scalars_kernel
-(unsigned *bucket_indices, unsigned *point_indices, fr_gpu *scalars, unsigned npoints, unsigned num_bucket_modules, unsigned c) {         
+(unsigned *bucket_indices, unsigned *point_indices, fr_gpu *scalars, unsigned npoints, unsigned num_bucket_modules, unsigned c) {   
+    
+    __syncthreads();//trying this bc the data should be caught up here to continue computations right?   
     unsigned bucket_index;
     unsigned current_index;
     fr_gpu scalar;


### PR DESCRIPTION
Add Device to Host transfer paradigm for bucket data and overloaded group element print operator.  MSM result continues to verify on larger memory GPU devices, aka. VMGPU3.1.  Note: MSM will not verify on smaller memory GPU devices, aka. VMGPU2.1